### PR TITLE
Move /usr/lib64/openmpi to main package

### DIFF
--- a/Dockerfile.centos:7
+++ b/Dockerfile.centos:7
@@ -32,12 +32,12 @@ RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 RUN echo -e "config_opts['yum.conf'] += \"\"\"\n\
 [openpa]\n\
 name=openpa\n\
-baseurl=https://build.hpdd.intel.com/daos-stack/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+baseurl=https://build.hpdd.intel.com/job/daos-stack/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
 gpgcheck = False\n\
 \n\
 [libfabric]\n\
 name=libfabric\n\
-baseurl=https://build.hpdd.intel.com/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+baseurl=https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
 gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg

--- a/Dockerfile.centos:7
+++ b/Dockerfile.centos:7
@@ -32,12 +32,12 @@ RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 RUN echo -e "config_opts['yum.conf'] += \"\"\"\n\
 [openpa]\n\
 name=openpa\n\
-baseurl=http://jenkins-3.wolf.hpdd.intel.com:8080/job/daos-stack-org/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+baseurl=https://build.hpdd.intel.com/daos-stack/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
 gpgcheck = False\n\
 \n\
 [libfabric]\n\
 name=libfabric\n\
-baseurl=http://jenkins-3.wolf.hpdd.intel.com:8080/job/daos-stack-org/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+baseurl=https://build.hpdd.intel.com/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
 gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME        := ompi
 VERSION     := 3.0.0rc4
-RELEASE     := 1
+RELEASE     := 2
 DIST        := $(shell rpm --eval %{dist})
 SRPM        := _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
 RPMS        := _topdir/RPMS/x86_64/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm           \

--- a/ompi.spec
+++ b/ompi.spec
@@ -72,7 +72,8 @@ find %{?buildroot}%{_libdir} -name *.la -print0 | xargs -r0 rm -f
 * Mon Mar 18 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-2
 - Obsoletes openmpi
 - Don't package libtool .la files
-- Include %{_libdir}/openmpi in the main package
+- Include %{_libdir}/openmpi/ in the main package
+- Only include the %{_libdir}/pkgconfig/* files in the devel package
 
 * Wed Mar 13 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-1
 - initial package

--- a/ompi.spec
+++ b/ompi.spec
@@ -1,6 +1,6 @@
 Name:		ompi
 Version:	3.0.0rc4
-Release:	1%{?dist}
+Release:	2%{?dist}
 
 Summary:	OMPI
 
@@ -17,6 +17,8 @@ BuildRequires: flex
 
 # to be able to generate configure if not present
 BuildRequires: autoconf, automake, libtool
+
+Obsoletes: openmpi
 
 %description
 OMPI
@@ -48,10 +50,11 @@ make %{?_smp_mflags} V=1
 
 %install
 %make_install
-
+find %{?buildroot}%{_libdir} -name *.la -print0 | xargs -r0 rm -f
 
 %files
 %{_libdir}/*.so.*
+%{_libdir}/openmpi/*.so
 %{_bindir}/*
 %{_datadir}/openmpi/
 %{_sysconfdir}/*
@@ -61,13 +64,15 @@ make %{?_smp_mflags} V=1
 %files devel
 %{_includedir}
 %{_libdir}/*.so
-%{_libdir}/*.la
-%{_libdir}/openmpi/*.so
-%{_libdir}/openmpi/*.la
-%{_libdir}/pkgconfig
+%{_libdir}/pkgconfig/*
 %{_mandir}/man3/*
 %{_mandir}/man7/*
 
 %changelog
+* Mon Mar 18 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-2
+- Obsoletes openmpi
+- Don't package libtool .la files
+- Include %{_libdir}/openmpi in the main package
+
 * Wed Mar 13 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-1
 - initial package


### PR DESCRIPTION
Also:
- Obsoletes openmpi
- Don't package libtool .la files
- Only include the %{_libdir}/pkgconfig/* files in the devel package