### PR TITLE
Require pmix >= 2.1.1

### DIFF
--- a/Dockerfile.centos:7
+++ b/Dockerfile.centos:7
@@ -40,7 +40,7 @@ gpgcheck = False\n\
 name=libfabric\n\
 baseurl=https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
-gpgcheck = False\n
+gpgcheck = False\n\
 [pmix]\n\
 name=pmix\n\
 baseurl=https://build.hpdd.intel.com/job/daos-stack/job/pmix/job/master/lastSuccessfulBuild/artifact/artifacts/\n\

--- a/Dockerfile.centos:7
+++ b/Dockerfile.centos:7
@@ -41,3 +41,8 @@ name=libfabric\n\
 baseurl=https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
 gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg
+[pmix]\n\
+name=pmix\n\
+baseurl=https://build.hpdd.intel.com/job/daos-stack/job/pmix/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+enabled=1\n\
+gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg

--- a/Dockerfile.centos:7
+++ b/Dockerfile.centos:7
@@ -40,7 +40,7 @@ gpgcheck = False\n\
 name=libfabric\n\
 baseurl=https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
 enabled=1\n\
-gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg
+gpgcheck = False\n
 [pmix]\n\
 name=pmix\n\
 baseurl=https://build.hpdd.intel.com/job/daos-stack/job/pmix/job/master/lastSuccessfulBuild/artifact/artifacts/\n\

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME        := ompi
 VERSION     := 3.0.0rc4
-RELEASE     := 2
+RELEASE     := 3
 DIST        := $(shell rpm --eval %{dist})
 SRPM        := _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
 RPMS        := _topdir/RPMS/x86_64/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm           \

--- a/ompi.spec
+++ b/ompi.spec
@@ -1,6 +1,6 @@
 Name:		ompi
 Version:	3.0.0rc4
-Release:	2%{?dist}
+Release:	3%{?dist}
 
 Summary:	OMPI
 
@@ -10,7 +10,7 @@ URL:		http://ompi-hpc.github.io/documentation/
 Source0:        https://www.github.com/open-mpi/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: hwloc-devel
-BuildRequires: pmix-devel
+BuildRequires: pmix-devel >= 2.1.1
 BuildRequires: libevent-devel
 BuildRequires: perl-Data-Dumper
 BuildRequires: flex
@@ -69,6 +69,9 @@ find %{?buildroot}%{_libdir} -name *.la -print0 | xargs -r0 rm -f
 %{_mandir}/man7/*
 
 %changelog
+* Mon Mar 18 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-3
+- Add a required verison of >= 2.1.1 for pmix-devel to make sure
+  to use our build which is newer than EPEL
 * Mon Mar 18 2019 Brian J. Murrell <brian.murrell@intel> - 3.0.0rc4-2
 - Obsoletes openmpi
 - Don't package libtool .la files


### PR DESCRIPTION
To avoid getting the one in EPEL.